### PR TITLE
Add Pybombs support. Add SoapySDR support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.9)
 project(ice9-bluetooth)
+INCLUDE(FindPkgConfig)
+
+# Install to PyBOMBS target prefix if defined
+if(DEFINED ENV{PYBOMBS_PREFIX})
+    set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})
+    set(PYBOMBS_PREFIX $ENV{PYBOMBS_PREFIX})
+    message(STATUS "PyBOMBS installed GNU Radio. Setting CMAKE_INSTALL_PREFIX to $ENV{PYBOMBS_PREFIX}")
+endif()
 
 set (CMAKE_CXX_STANDARD 17)
 
@@ -34,6 +42,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 # Add required dependencies
+find_package(SoapySDR REQUIRED)
 find_package(HackRF REQUIRED)
 find_package(BladeRF REQUIRED)
 find_package(UHD REQUIRED)
@@ -70,6 +79,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${SOAPYSDR_INCLUDE_DIR})
 include_directories(${LIBHACKRF_INCLUDE_DIR})
 include_directories(${LIBBLADERF_INCLUDE_DIR})
 include_directories(${UHD_INCLUDE_DIR})
@@ -81,6 +91,7 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/btbb/btbb.c
     ${PROJECT_SOURCE_DIR}/burst_catcher.c
     ${PROJECT_SOURCE_DIR}/fsk.c
+    ${PROJECT_SOURCE_DIR}/soapysdr.c
     ${PROJECT_SOURCE_DIR}/hackrf.c
     ${PROJECT_SOURCE_DIR}/hash.c
     ${PROJECT_SOURCE_DIR}/help.c
@@ -91,6 +102,8 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/window.c
 
     ${PROJECT_SOURCE_DIR}/main.c
+        soapysdr.c
+        soapysdr.h
 )
 
 if(USE_VKFFT)
@@ -130,6 +143,7 @@ target_link_libraries(ice9-bluetooth
     PRIVATE Threads::Threads
     m
     ${LIBHACKRF_LIBRARIES}
+    ${SOAPYSDR_LIBRARIES}
     ${LIBBLADERF_LIBRARIES}
     ${UHD_LIBRARIES}
     ${LIQUID_LIBRARIES}

--- a/cmake/Modules/FindBladeRF.cmake
+++ b/cmake/Modules/FindBladeRF.cmake
@@ -14,6 +14,7 @@ find_path(LIBBLADERF_INCLUDE_DIR
     NAMES libbladeRF.h
     HINTS
         ${LIBBLADERF_DIR}/include
+        ${PYBOMBS_PREFIX}/include
         ${PC_LIBBLADERF_INCLUDEDIR}
         ${PC_LIBBLADERF_INCLUDE_DIRS}
         /opt/homebrew/include
@@ -27,6 +28,7 @@ find_library(LIBBLADERF_LIBRARY
     HINTS
         $ENV{LIBBLADERF_DIR}/lib
         ${PC_LIBBLADERF_LIBDIR}
+        ${PYBOMBS_PREFIX}/lib
         ${PC_LIBBLADERF_LIBRARY_DIRS}
         /opt/homebrew/lib
         /opt/local/lib

--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -64,7 +64,7 @@ if( FFTW_ROOT )
     find_library(
         FFTW_DOUBLE_LIB
         NAMES "fftw3" libfftw3-3
-        PATHS ${FFTW_ROOT}
+        PATHS ${FFTW_ROOT} ${PYBOMBS_PREFIX}
         PATH_SUFFIXES "lib" "lib64"
         NO_DEFAULT_PATH
         )

--- a/cmake/Modules/FindHackRF.cmake
+++ b/cmake/Modules/FindHackRF.cmake
@@ -16,6 +16,7 @@ find_path(LIBHACKRF_INCLUDE_DIR
         $ENV{LIBHACKRF_DIR}/include
         ${PC_LIBHACKRF_INCLUDEDIR}
         ${PC_LIBHACKRF_INCLUDE_DIRS}
+        ${PYBOMBS_PREFIX}/include/libhackrf
         /opt/homebrew/include
         /opt/local/include
         /home/linuxbrew/.linuxbrew/include
@@ -28,6 +29,7 @@ find_library(LIBHACKRF_LIBRARY
     NAMES hackrf
     HINTS
         $ENV{LIBHACKRF_DIR}/lib
+        ${PYBOMBS_PREFIX}/lib
         ${PC_LIBHACKRF_LIBDIR}
         ${PC_LIBHACKRF_LIBRARY_DIRS}
         /opt/homebrew/lib

--- a/cmake/Modules/FindLiquid.cmake
+++ b/cmake/Modules/FindLiquid.cmake
@@ -16,6 +16,7 @@ find_path(LIQUID_INCLUDE_DIR
         ${LIQUID_DIR}/include
         ${PC_LIQUID_INCLUDEDIR}
         ${PC_LIQUID_INCLUDE_DIRS}
+        ${PYBOMBS_PREFIX}/include/liquid
         /opt/homebrew/include
         /home/linuxbrew/.linuxbrew/include
         /opt/local/include
@@ -28,6 +29,7 @@ find_library(LIQUID_LIBRARY
     NAMES liquid
     HINTS
         $ENV{LIQUID_DIR}/lib
+        ${PYBOMBS_PREFIX}/lib
         ${PC_LIQUID_LIBDIR}
         ${PC_LIQUID_LIBRARY_DIRS}
         /opt/homebrew/lib

--- a/cmake/Modules/FindSoapySDR.cmake
+++ b/cmake/Modules/FindSoapySDR.cmake
@@ -1,0 +1,33 @@
+message(STATUS "FINDING SOAPY.")
+if(NOT SOAPYSDR_FOUND)
+  pkg_check_modules (SOAPYSDR_PKG SoapySDR)
+
+  find_path(SOAPYSDR_INCLUDE_DIRS 
+    NAMES SoapySDR/Device.h
+    HINTS $ENV{SOAPY_DIR}/include ${PYBOMBS_PREFIX}/include/SoapySDR
+    PATHS ${SOAPYSDR_PKG_INCLUDE_DIRS}
+          /usr/include
+          /usr/local/include
+  )
+
+  find_library(SOAPYSDR_LIBRARIES 
+    NAMES SoapySDR
+    HINTS $ENV{SOAPY_DIR}/lib ${PYBOMBS_PREFIX}/lib
+    PATHS ${SOAPYSDR_PKG_LIBRARY_DIRS}
+          /usr/lib
+          /usr/local/lib
+          /usr/lib/arm-linux-gnueabihf     
+  )
+
+
+if(SOAPYSDR_INCLUDE_DIRS AND SOAPYSDR_LIBRARIES)
+  set(SOAPYSDR_FOUND TRUE CACHE INTERNAL "libSOAPYSDR found")
+  message(STATUS "Found libSOAPYSDR: ${SOAPYSDR_INCLUDE_DIRS}, ${SOAPYSDR_LIBRARIES}")
+else(SOAPYSDR_INCLUDE_DIRS AND SOAPYSDR_LIBRARIES)
+  set(SOAPYSDR_FOUND FALSE CACHE INTERNAL "libSOAPYSDR found")
+  message(STATUS "libSOAPYSDR not found.")
+endif(SOAPYSDR_INCLUDE_DIRS AND SOAPYSDR_LIBRARIES)
+
+mark_as_advanced(SOAPYSDR_LIBRARIES SOAPYSDR_INCLUDE_DIRS)
+
+endif(NOT SOAPYSDR_FOUND)

--- a/cmake/Modules/FindUHD.cmake
+++ b/cmake/Modules/FindUHD.cmake
@@ -14,6 +14,7 @@ find_path(UHD_INCLUDE_DIR
     NAMES uhd/config.hpp
     HINTS
         ${UHD_DIR}/include
+        ${PYBOMBS_PREFIX}/include
         ${PC_UHD_INCLUDEDIR}
         ${PC_UHD_INCLUDE_DIRS}
         /opt/homebrew/include
@@ -26,6 +27,7 @@ find_library(UHD_LIBRARY
     NAMES uhd
     HINTS
         ${UHD_DIR}/lib
+        ${PYBOMBS_PREFIX}/lib
         ${PC_UHD_LIBDIR}
         ${PC_UHD_LIBRARY_DIRS}
         /opt/homebrew/lib

--- a/fsk.c
+++ b/fsk.c
@@ -51,7 +51,7 @@ static int cfo_median(fsk_demod_t *fsk, float *demod, unsigned burst_len, float 
 
     // find the median of the positive and negative points
     for (i = 8; i < 8 + median_size(); ++i) {
-        if (fabsf(demod[i]) > max_freq_offset)
+        if (fabsf((float)demod[i]) > max_freq_offset)
             return 0;
         if (demod[i] > 0)
             fsk->pos_points[pos_count++] = demod[i];

--- a/options.c
+++ b/options.c
@@ -22,6 +22,7 @@
 
 #include "hackrf.h"
 #include "bladerf.h"
+#include "soapysdr.h"
 #include "pcap.h"
 #include "usrp.h"
 
@@ -29,6 +30,7 @@ extern FILE *in;
 extern char *serial;
 extern char *usrp_serial;
 extern int bladerf_num;
+extern int soapysdr_num;
 
 extern float samp_rate;
 extern unsigned channels;
@@ -86,6 +88,7 @@ static void _print_interfaces(void) {
     hackrf_list();
     bladerf_list();
     usrp_list();
+    soapysdr_list();
     exit(0);
 }
 
@@ -148,8 +151,10 @@ void parse_options(int argc, char **argv) {
                     bladerf_num = atoi(optarg + strlen("bladerf"));
                 else if (strstr(optarg, "usrp-") == optarg)
                     usrp_serial = strdup(usrp_get_serial(optarg));
+                else if (strstr(optarg, "soapy-") == optarg)
+                    soapysdr_num = atoi(optarg + strlen("soapy-"));
                 else
-                    errx(1, "invalid interface, must start with \"hackrf-\" or \"bladerf\"");
+                    errx(1, "invalid interface, must start with \"hackrf-\" or \"bladerf\" or \"soapy-\"");
                 break;
 
             case 'w':

--- a/soapysdr.c
+++ b/soapysdr.c
@@ -1,0 +1,229 @@
+#include "soapysdr.h"
+#include "sdr.h"
+#include <SoapySDR/Formats.h>
+#include <SoapySDR/Device.h>
+#include <complex.h>
+#include <err.h>
+#include <malloc.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+const int soapysdr_gain_val = 64;
+extern sig_atomic_t running;
+extern pid_t self_pid;
+extern unsigned channels;
+extern float samp_rate;
+extern unsigned center_freq;
+void (*rx_chain)(void*,int,float);
+
+void soapysdr_list(void) {
+    size_t soapysdrdevs;
+    SoapySDRKwargs* soapysdrdevices;
+
+    soapysdrdevices = SoapySDRDevice_enumerate(NULL, &soapysdrdevs);
+    for (size_t j = 0; j < soapysdrdevs; j++)
+    {
+        char buffer[256]={0};
+        snprintf(buffer,255,"interface {value=soapy-%d}{display=ICE9 Bluetooth} => ", (int)j);
+        for (size_t k = 0; k < soapysdrdevices[j].size; k++)
+        {
+            snprintf(buffer+strlen(buffer),255-strlen(buffer), "%s=%s, ", soapysdrdevices[j].keys[k], soapysdrdevices[j].vals[k]);
+        }
+        snprintf(buffer+strlen(buffer)-2,255-strlen(buffer)+2, "%s", "\n");
+        printf("%s",buffer);
+    }
+    SoapySDRKwargsList_clear(soapysdrdevices, soapysdrdevs);
+}
+
+
+struct SoapySDRDevice *soapysdr_setup(int id)
+{
+    char identifier[32];
+    size_t length=0;
+    SoapySDRKwargs *results = SoapySDRDevice_enumerate(NULL, &length);
+    if (length==0 || id>(int)length)
+    {
+        errx(1,"Unable to detect SoapySDR device %d :(",id);
+    }
+    SoapySDRDevice *sdr = SoapySDRDevice_make(&results[id]);
+    if (sdr == NULL)
+    {
+        errx(1,"SoapySDRDevice_make fail: %s",SoapySDRDevice_lastError());
+    }
+    snprintf(identifier, sizeof(identifier), "*:instance=%d", id);
+
+
+    double* samplerates=SoapySDRDevice_listSampleRates(sdr,SOAPY_SDR_RX,0,&length);
+    printf("Trying to set a samplerate of %f\n", samp_rate);
+    float tmprate=samp_rate;
+    for (size_t x=0;x<length;x++)
+    {
+        double device_samplerate=samplerates[x];
+        if (device_samplerate>=samp_rate) {
+            tmprate = device_samplerate;
+        }
+        if (device_samplerate == samp_rate)
+        {
+            break;
+        }
+    }
+    samp_rate = tmprate;
+    printf("Setting a device samplerate of %f\n", samp_rate);
+    if (SoapySDRDevice_setSampleRate(sdr, SOAPY_SDR_RX, 0, samp_rate) != 0)
+    {
+        errx(1,"Unable to set soapysdr sample rate: %s", SoapySDRDevice_lastError());
+    }
+
+    size_t         bw_length;
+    SoapySDRRange* bw_range = SoapySDRDevice_getBandwidthRange(sdr, SOAPY_SDR_RX, 0, &bw_length);
+    for (size_t k = 0; k < bw_length; ++k) {
+        double bw = samp_rate * 0.75;
+        bw        = MIN(bw, bw_range[k].maximum);
+        bw        = MAX(bw, bw_range[k].minimum);
+        if (SoapySDRDevice_setBandwidth(sdr, SOAPY_SDR_RX, 0, bw) != 0) {
+            errx(1,"setBandwidth fail: %s\n", SoapySDRDevice_lastError());
+        }
+        printf("Set Rx bandwidth to %.2f MHz\n", SoapySDRDevice_getBandwidth(sdr, SOAPY_SDR_RX, 0) / 1e6);
+    }
+
+    if (SoapySDRDevice_setFrequency(sdr, SOAPY_SDR_RX, 0, center_freq*1e6, NULL) != 0) {
+        errx(1,"Unable to set soapysdr center frequency: %s", SoapySDRDevice_lastError());
+    }
+    else {
+        printf("Setting a frequency of %.2f MHz\n", center_freq*1e6/1e6);
+    }
+
+    if (SoapySDRDevice_setGainMode(sdr,SOAPY_SDR_RX,0,0) != 0) {
+        errx(1,"Unable to set soapysdr gain mode to non-automatic: %s", SoapySDRDevice_lastError());
+    } else {
+        printf("Gain mode set to manual.\n");
+    }
+
+    SoapySDRRange gain_range = SoapySDRDevice_getGainRange(sdr, SOAPY_SDR_RX, 0);
+    int max_gain = gain_range.maximum;
+    int min_gain = gain_range.minimum;
+    int gain = (int)(((max_gain-min_gain)*0.75)+min_gain);
+    printf("Gain range: %d to %d\n",min_gain,max_gain);
+
+
+    printf("Setting a device gain val of %d\n", gain);
+    if (SoapySDRDevice_setGain(sdr,SOAPY_SDR_RX,0,gain) != 0)
+    {
+        errx(1,"Unable to set soapysdr gain : %s", SoapySDRDevice_lastError());
+    }
+
+    return sdr;
+}
+
+static int soapy_rx_cs8(const int8_t* buffer, size_t num_samples, float fullScale) {
+    sample_buf_t *s = malloc(sizeof(*s) + num_samples * sizeof(int16_t));
+    s->num = num_samples;
+    memcpy(s->samples,buffer,s->num);
+    if (running)
+        push_samples(s);
+    else
+        free(s);
+    return 0;
+}
+
+static int soapy_rx_cs16(const int16_t* buffer, size_t num_samples, float fullScale) {
+    unsigned i;
+    sample_buf_t *s = malloc(sizeof(*s) + num_samples * sizeof(int16_t));
+    s->num = num_samples;
+    for (i = 0; i < s->num*2; ++i) {
+        s->samples[i] = buffer[i]/128 + buffer[i+1]/128 * I;
+    }
+    //printf("%d\n", ((int32_t)buffer[i] + buffer[i+1]) * I)/1024.0f;
+    if (running)
+        push_samples(s);
+    else
+        free(s);
+    return 0;
+}
+
+
+void *soapysdr_stream_thread(void *arg)
+{
+    SoapySDRDevice *sdr = arg;
+    //setup a stream (complex floats)
+    double fullScale;
+    char *native_stream_format = SoapySDRDevice_getNativeStreamFormat(sdr,SOAPY_SDR_RX,0,&fullScale);
+    int format;
+    SoapySDRStream *rxStream = NULL;
+    if (strcmp(native_stream_format,SOAPY_SDR_CS16)==0)
+    {
+        printf("Trying CS16->CS8\n");
+        format = 8;
+        rxStream = SoapySDRDevice_setupStream(sdr, SOAPY_SDR_RX, SOAPY_SDR_CS8, NULL, 0,
+                                              NULL);
+        if (rxStream == NULL) {
+        printf("Using Format CS16.\n");
+        format = 16;
+        rxStream = SoapySDRDevice_setupStream(sdr, SOAPY_SDR_RX, SOAPY_SDR_CS16, NULL, 0,
+                                              NULL);
+        }
+    }
+    else if (strcmp(native_stream_format,SOAPY_SDR_CS8)==0)
+    {
+        printf("Using Format CS8.\n");
+        format = 8;
+        rxStream = SoapySDRDevice_setupStream(sdr, SOAPY_SDR_RX, SOAPY_SDR_CS8, NULL, 0,
+                                              NULL);
+    }
+    else
+    {
+        printf("Format not supported.\n");
+        return (void*)NULL;
+    }
+    if (rxStream == NULL)
+    {
+        printf("setupStream fail: %s\n", SoapySDRDevice_lastError());
+        SoapySDRDevice_unmake(sdr);
+        return (void*)NULL;
+    }
+    SoapySDRDevice_activateStream(sdr, rxStream, 0, 0, 0); //start streaming
+
+    //create a re-usable buffer for rx samples
+
+    unsigned samples_per_buffer = channels / 2 * 4096;
+    complex float *samples=(uint16_t*)malloc(samples_per_buffer*sizeof(complex float)*2);
+    unsigned timeout=100000 * channels / 2 * 4096 / samp_rate;
+
+
+    if (format==8)
+    {
+        rx_chain = (void*)soapy_rx_cs8;
+    }
+    else {
+        rx_chain = (void*)soapy_rx_cs16;
+    }
+    while (running)
+    {
+        //receive some samples
+        void *buffs[] = {samples}; //array of buffers
+        int flags; //flags set by receive operation
+        long long timeNs; //timestamp for receive buffer
+        int ret = SoapySDRDevice_readStream(sdr, rxStream, buffs, samples_per_buffer, &flags, &timeNs, timeout);
+        if (ret>0)
+        {
+            //printf("ret=%d, flags=%d, timeNs=%lld\n", ret, flags, timeNs);
+            rx_chain(buffs[0], ret, fullScale);
+        }
+        //else printf("U");
+    }
+    free(samples);
+    //shutdown the stream
+    SoapySDRDevice_deactivateStream(sdr, rxStream, 0, 0); //stop streaming
+    SoapySDRDevice_closeStream(sdr, rxStream);
+
+    //cleanup device handle
+    SoapySDRDevice_unmake(sdr);
+
+    printf("Done\n");
+    return (void*)NULL;
+}

--- a/soapysdr.h
+++ b/soapysdr.h
@@ -1,0 +1,9 @@
+#ifndef ICE9_BLUETOOTH_SNIFFER_SOAPYSDR_H
+#define ICE9_BLUETOOTH_SNIFFER_SOAPYSDR_H
+#include <SoapySDR/Device.h>
+
+struct SoapySDRDevice *soapysdr_setup(int id);
+void soapysdr_list(void);
+void *soapysdr_stream_thread(void *arg);
+
+#endif // ICE9_BLUETOOTH_SNIFFER_SOAPYSDR_H


### PR DESCRIPTION
This fixes compile issues with gnuradio/pybombs and adds support for SoapySDR. Tested with SoapyUHD and UsrpB210, best setting is with:
```bash 
ice9-bluetooth -C 32 -l -s -v -i soapy-0 -w out.pcap
```