### PR TITLE
burst_catcher: report AGC values, and plumb those as rssi all the way down to pcap

### DIFF
--- a/bluetooth.c
+++ b/bluetooth.c
@@ -98,13 +98,15 @@ ble_packet_t *ble_burst(uint8_t *bits, unsigned bits_len, unsigned freq, struct 
     return NULL;
 }
 
-void bluetooth_detect(uint8_t *bits, unsigned len, unsigned freq, struct timespec timestamp, uint32_t *lap_out, uint32_t *aa_out) {
+void bluetooth_detect(uint8_t *bits, unsigned len, unsigned freq, unsigned rssi, unsigned noise, struct timespec timestamp, uint32_t *lap_out, uint32_t *aa_out) {
     uint32_t lap = btbb_find_ac((char *)bits, len, 1);
     if (lap != 0xffffffff) {
         *lap_out = lap;
     } else {
         ble_packet_t * p = ble_burst(bits, len, freq, timestamp);
         if (p != NULL) {
+            p->rssi_db = rssi;
+            p->noise_db = noise;
             *aa_out = p->aa;
             if (pcap)
                 pcap_write_ble(pcap, p);

--- a/bluetooth.h
+++ b/bluetooth.h
@@ -8,10 +8,12 @@
 #include <stdint.h>
 #include <time.h>
 
-void bluetooth_detect(uint8_t *bits, unsigned len, unsigned freq, struct timespec timestamp, uint32_t *lap_out, uint32_t *aa_out);
+void bluetooth_detect(uint8_t *bits, unsigned len, unsigned freq, unsigned rssi, unsigned noise, struct timespec timestamp, uint32_t *lap_out, uint32_t *aa_out);
 
 typedef struct _ble_packet_t {
     uint32_t aa;
+    int rssi_db;
+    int noise_db;
     unsigned freq; // frequency in MHz
     unsigned len; // length including AA + header + CRC
     struct timespec timestamp;

--- a/burst_catcher.h
+++ b/burst_catcher.h
@@ -17,6 +17,7 @@ typedef struct _burst_catcher_t {
     unsigned burst_len;
     unsigned burst_buf_size;
     unsigned burst_num;
+    float burst_rssi;
     struct timespec timestamp;
 } burst_catcher_t;
 
@@ -26,6 +27,7 @@ typedef struct _burst_t {
     unsigned freq;
     packet_t packet;
     unsigned num;
+    float rssi_db, noise_db;
     struct timespec timestamp;
 } burst_t;
 

--- a/main.c
+++ b/main.c
@@ -382,10 +382,10 @@ void *burst_processor_thread(void *arg) {
 
         if (burst->packet.demod != NULL && burst->packet.bits != NULL) {
             uint32_t lap = 0xffffffff, aa = 0xffffffff;
-            bluetooth_detect(burst->packet.bits, burst->packet.bits_len, burst->freq, burst->timestamp, &lap, &aa);
+            bluetooth_detect(burst->packet.bits, burst->packet.bits_len, burst->freq, burst->rssi_db, burst->noise_db, burst->timestamp, &lap, &aa);
 
             if (verbose) {
-                printf("burst %4u-%04u ", burst->freq, burst->num);
+                printf("burst %4u-%04u, %d samps, rssi %f dB, noise %f dB ", burst->freq, burst->num, burst->len, burst->rssi_db, burst->noise_db);
                 printf("cfo %f deviation %f ", burst->packet.cfo, burst->packet.deviation);
                 if (lap != 0xffffffff)
                     printf("lap %06x", lap);

--- a/pcap.c
+++ b/pcap.c
@@ -37,7 +37,10 @@ typedef struct __attribute__((packed)) _pcap_le_header_t {
     uint16_t flags;
 } pcap_le_header_t;
 
-#define LE_DEWHITENED 0x0001
+#define LE_DEWHITENED         0x0001
+#define LE_SIGNAL_POWER_VALID 0x0002
+#define LE_NOISE_POWER_VALID  0x0004
+
 
 #if !defined( DLT_BLUETOOTH_LE_LL_WITH_PHDR )
 #define DLT_BLUETOOTH_LE_LL_WITH_PHDR 256
@@ -74,7 +77,9 @@ void pcap_close(pcap_t *p) {
 void pcap_write_ble(pcap_t *p, ble_packet_t *b) {
     pcap_le_header_t le_header = {
         .rf_channel = (b->freq - 2402) / 2,
-        .flags = LE_DEWHITENED,
+        .signal_power = b->rssi_db,
+        .noise_power = b->noise_db,
+        .flags = LE_DEWHITENED | LE_SIGNAL_POWER_VALID | LE_NOISE_POWER_VALID,
     };
     pcaprec_hdr_t pcap_header = {
         .ts_sec   = b->timestamp.tv_sec,


### PR DESCRIPTION
It'd be nice to know just how close to the noise floor we are.  Luckily, we can know!  Grab the AGC value a few samples into the burst, and store that as the RSSI; then, grab the AGC value *after* the burst, and store that as the noise floor.  Plumb those into pcap.